### PR TITLE
fix(home.js): resolve image overflow causing scrollbar by adding Tailwind css class

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -79,7 +79,7 @@ const Home = () => {
 					)}
 				</div>
 				<div className="h-full bg-secondary w-2/4 sm:flex hidden items-center justify-center px-4">
-					<img src="/landing page image.jpg" className="h-auto rounded-full w-auto object-cover" />
+					<img src="/landing page image.jpg" className="max-h-[90vh] rounded-full w-auto object-cover" />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION

# Fixes Issue

**My PR closes #747**

# 👨‍💻 Changes proposed(What did you do ?)

The issue of unwanted scrollbars appearing due to image overflow was fixed by applying Tailwind CSS classes ( max-h-[90vh] )to the <img> tag and removed 'h-auto' class because it was not required. The change will cause image to resize according to the available space and will not overflow due to different aspect ratio of screen.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
before
![image](https://github.com/user-attachments/assets/1d137898-c40a-43ac-af7a-897c53fed3b2)
after
![image](https://github.com/user-attachments/assets/270df489-b94c-4ccf-b318-fe1aa2349551)


<!-- Add all the screenshots which support your changes -->
